### PR TITLE
unzips tracks.csv.zip (49.9Mb)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-tracks
+tracks.csv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/sl-deploy.py
+++ b/sl-deploy.py
@@ -10,12 +10,21 @@ import os
 import numpy as np
 from scipy import stats
 import csv
+import zipfile
 
 #####
 ## df > dfp --- plot all correlations for keys and modes by themselves
 ## dfp > m0/m1 --- plot all correlations for modes
 ## mo/m1 > m0k0/m1k0 --- plot all correlations for keys in modes
 #####
+
+# if track.csv does not exists, unzip it from tracks.csv.zip
+# (Make sure to put tracks.csv into .gitignore!)
+if glob.glob("tracks.csv") == []:
+    zf = zipfile.ZipFile('tracks.csv.zip','r')
+    #print(zf.infolist())
+    r = zf.extract("tracks.csv")
+    print("Extracted tracks.csv.zip into", r)
 
 # Read in all CSV 
 df = pd.read_csv("tracks.csv", index_col=None, header=0)


### PR DESCRIPTION
I've added the zipped version of the tracks (tracks.csv.zip) back, which is just small enough to be legal on github and gave you some code to unzip it into tracks.csv, if that doesn't exists. I've also added tracks.csv to your gitignore so it won't get pushed to github. All you need to do is manually remove your current (smaller) tracks.csv file and you'll get the full csv file when you run your code.